### PR TITLE
Agrega endpoints profile y auth context

### DIFF
--- a/sales-order-backend/src/auth/auth.controller.ts
+++ b/sales-order-backend/src/auth/auth.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { Public } from './public.decorator';
+import { JwtUser } from './jwt-user';
 
 @Controller('auth')
 export class AuthController {
@@ -14,5 +15,11 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto.username, dto.password);
+  }
+
+  @Get('me')
+  @HttpCode(HttpStatus.OK)
+  me(@Req() req: { user: JwtUser }) {
+    return req.user;
   }
 }

--- a/sales-order-backend/src/modules/users/dto/update-own-profile.dto.ts
+++ b/sales-order-backend/src/modules/users/dto/update-own-profile.dto.ts
@@ -1,0 +1,23 @@
+import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * Solo campos que el usuario puede cambiar sobre sí mismo.
+ * Nunca rol, contraseña ni isActive desde este DTO.
+ */
+export class UpdateOwnProfileDto {
+  @IsOptional()
+  @IsString({ message: 'El nombre debe ser texto' })
+  @MinLength(1, { message: 'El nombre no puede estar vacío' })
+  @MaxLength(200, { message: 'El nombre es demasiado largo' })
+  name?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'El correo electrónico debe ser válido' })
+  @MaxLength(320, { message: 'El correo es demasiado largo' })
+  email?: string;
+
+  @IsOptional()
+  @IsString({ message: 'El teléfono debe ser texto' })
+  @MaxLength(40, { message: 'El teléfono es demasiado largo' })
+  phone?: string;
+}

--- a/sales-order-backend/src/modules/users/users.controller.ts
+++ b/sales-order-backend/src/modules/users/users.controller.ts
@@ -20,6 +20,7 @@ import { JwtUser } from '../../auth/jwt-user';
 import { UserRole } from '../../entities/user.entity';
 import { ChangeOwnPasswordDto } from './dto/change-own-password.dto';
 import { CreateUserDTO } from './dto/create-user-dto';
+import { UpdateOwnProfileDto } from './dto/update-own-profile.dto';
 import { UpdateUserDTO } from './dto/update-user-dto';
 import { UserResponseDTO } from './dto/user-response-dto';
 import { UsersService } from './users.service';
@@ -37,6 +38,8 @@ export class UsersController {
   }
 
   @Get()
+  @Roles(UserRole.ADMIN)
+  @UseGuards(RolesGuard)
   async findAll(): Promise<UserResponseDTO[]> {
     return this.usersService.findAll();
   }
@@ -53,12 +56,30 @@ export class UsersController {
     );
   }
 
+  /** Perfil del usuario autenticado (debe declararse antes de @Get(':id')). */
+  @Get('me')
+  async findMe(@Req() req: Request & { user: JwtUser }): Promise<UserResponseDTO> {
+    return this.usersService.findOne(req.user.userId);
+  }
+
+  @Patch('me')
+  async updateMe(
+    @Req() req: Request & { user: JwtUser },
+    @Body() dto: UpdateOwnProfileDto,
+  ): Promise<UserResponseDTO> {
+    return this.usersService.updateOwnProfile(req.user.userId, dto);
+  }
+
   @Get(':id')
+  @Roles(UserRole.ADMIN)
+  @UseGuards(RolesGuard)
   async findOne(@Param('id', ParseIntPipe) id: number): Promise<UserResponseDTO> {
     return this.usersService.findOne(id);
   }
 
   @Put(':id')
+  @Roles(UserRole.ADMIN)
+  @UseGuards(RolesGuard)
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDTO,

--- a/sales-order-backend/src/modules/users/users.service.ts
+++ b/sales-order-backend/src/modules/users/users.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -9,6 +10,7 @@ import { Repository, QueryDeepPartialEntity } from 'typeorm';
 import { User, UserRole } from '../../entities/user.entity';
 import { CreateUserDTO } from './dto/create-user-dto';
 import { UpdateUserDTO } from './dto/update-user-dto';
+import { UpdateOwnProfileDto } from './dto/update-own-profile.dto';
 import { UserResponseDTO } from './dto/user-response-dto';
 import * as bcrypt from 'bcrypt';
 
@@ -71,6 +73,60 @@ export class UsersService {
     return this.userRepository.findOne({
       where: { username, isActive: true },
     });
+  }
+
+  /**
+   * Actualización restringida al perfil propio: no expone vía API campos privilegiados.
+   */
+  async updateOwnProfile(userId: number, dto: UpdateOwnProfileDto): Promise<UserResponseDTO> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId, isActive: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`Usuario con ID ${userId} no encontrado`);
+    }
+
+    const name = dto.name !== undefined ? dto.name.trim() : undefined;
+    const email = dto.email !== undefined ? dto.email.trim().toLowerCase() : undefined;
+    const phone = dto.phone !== undefined ? dto.phone.trim() : undefined;
+
+    if (name !== undefined && name.length === 0) {
+      throw new BadRequestException('El nombre no puede estar vacío');
+    }
+    if (email !== undefined && email.length === 0) {
+      throw new BadRequestException('El correo electrónico no puede estar vacío');
+    }
+
+    if (email !== undefined && email !== user.email) {
+      const emailTaken = await this.userRepository.findOne({
+        where: { email },
+      });
+      if (emailTaken && emailTaken.id !== userId) {
+        throw new ConflictException('El correo electrónico ya está en uso');
+      }
+    }
+
+    const updateData: QueryDeepPartialEntity<User> = {};
+    if (name !== undefined) updateData.name = name;
+    if (email !== undefined) updateData.email = email;
+    if (phone !== undefined) updateData.phone = phone;
+
+    if (Object.keys(updateData).length === 0) {
+      return this.mapToResponseDTO(user);
+    }
+
+    await this.userRepository.update(userId, updateData);
+
+    const updatedUser = await this.userRepository.findOne({
+      where: { id: userId, isActive: true },
+    });
+
+    if (!updatedUser) {
+      throw new NotFoundException(`Usuario con ID ${userId} no encontrado tras la actualización`);
+    }
+
+    return this.mapToResponseDTO(updatedUser);
   }
 
   async changePassword(

--- a/src/components/desktop/Header/HeaderDesktop.tsx
+++ b/src/components/desktop/Header/HeaderDesktop.tsx
@@ -4,12 +4,13 @@ import BtnBlue from '../../common/BtnBlue/BtnBlue';
 import HeaderNotification from '../HeaderNotification/HeaderNotification';
 import CreateLink from '../../../pages/Admin/mobile/Orders/CreateLink';
 import { ordersService, OrderStatus } from '../../../services/ordersService';
-import { logout as authLogout } from '../../../services/authService';
+import { useAuth } from '../../../context/AuthContext';
 import './HeaderDesktop.css';
 
 const HeaderDesktop = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { user, logout } = useAuth();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showCreateLinkPopup, setShowCreateLinkPopup] = useState(false);
   const [pendingOrdersCount, setPendingOrdersCount] = useState(0);
@@ -48,7 +49,7 @@ const HeaderDesktop = () => {
   };
 
   const handleLogout = () => {
-    authLogout();
+    logout();
     setShowUserMenu(false);
     navigate('/login');
   };
@@ -91,7 +92,7 @@ const HeaderDesktop = () => {
       </div>
 
       <div className="header-right">
-        <span className="header-right-text">Bienvenido, {'user.name'}</span>
+        <span className="header-right-text">Bienvenido, {user?.username ?? 'Usuario'}</span>
         <div className="user-menu-container">
           <button 
             className="user-avatar"

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { getCurrentUser, loginRequest, logout as authLogout, type LoginUser } from '../services/authService';
+import { getStoredToken } from '../services/http';
+
+type AuthStatus = 'loading' | 'authenticated' | 'anonymous';
+
+type AuthContextValue = {
+  user: LoginUser | null;
+  status: AuthStatus;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+  refreshSession: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<LoginUser | null>(null);
+  const [status, setStatus] = useState<AuthStatus>('loading');
+
+  const logout = useCallback(() => {
+    authLogout();
+    setUser(null);
+    setStatus('anonymous');
+  }, []);
+
+  const refreshSession = useCallback(async () => {
+    if (!getStoredToken()) {
+      setUser(null);
+      setStatus('anonymous');
+      return;
+    }
+
+    try {
+      const currentUser = await getCurrentUser();
+      setUser(currentUser);
+      setStatus('authenticated');
+    } catch {
+      authLogout();
+      setUser(null);
+      setStatus('anonymous');
+    }
+  }, []);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const { user: loggedInUser } = await loginRequest(username, password);
+    setUser(loggedInUser);
+    setStatus('authenticated');
+  }, []);
+
+  useEffect(() => {
+    void refreshSession();
+  }, [refreshSession]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      status,
+      login,
+      logout,
+      refreshSession,
+    }),
+    [user, status, login, logout, refreshSession],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { createBrowserRouter, RouterProvider, Navigate } from "react-router-dom";
 import Login from './pages/Login';
-import { getStoredToken } from './services/http';
 import Orders from './pages/Admin/mobile/Orders/Orders';
 import Reports from './pages/Admin/mobile/Reports/Reports';
 import Manage from './pages/Admin/mobile/Manage/Manage';
@@ -32,6 +31,7 @@ import EditPassword from './pages/Admin/mobile/Profile/EditPassword';
 import EditProfile from './pages/Admin/mobile/Profile/EditProfile';
 import { useIsDesktop } from './hooks/useIsDesktop';
 import CustomerDesktop from './pages/Customer/desktop/CustomerDesktop';
+import { AuthProvider, useAuth } from './context/AuthContext';
 
 const NewOrderRoute = () => {
   const isDesktop = useIsDesktop();
@@ -54,7 +54,13 @@ const HistoryOrderDetailsRoute = () => {
 };
 
 function RequireAuth({ children }: { children: ReactNode }) {
-  if (!getStoredToken()) {
+  const { status } = useAuth();
+
+  if (status === 'loading') {
+    return null;
+  }
+
+  if (status !== 'authenticated') {
     return <Navigate to="/login" replace />;
   }
   return <>{children}</>;
@@ -186,6 +192,8 @@ if (!rootElement) throw new Error('Failed to find the root element');
 
 createRoot(rootElement).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/src/pages/Admin/mobile/Profile/EditProfile.tsx
+++ b/src/pages/Admin/mobile/Profile/EditProfile.tsx
@@ -1,91 +1,199 @@
-﻿import Header from "../../../../components/common/Header/Header";
-import { Link } from "react-router-dom";
-import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
-import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue";
-import FormField from "../../../../components/common/FormField/FormField";
-import { useState } from "react";
+﻿import Header from '../../../../components/common/Header/Header';
+import { Link } from 'react-router-dom';
+import SectionTitle from '../../../../components/common/SectionTitle/SectionTitle';
+import BtnBlue from '../../../../components/common/BtnBlue/BtnBlue';
+import FormField from '../../../../components/common/FormField/FormField';
+import { useCallback, useEffect, useState } from 'react';
 import './Profile.css';
+import { useAuth } from '../../../../context/AuthContext';
+import { fetchMyProfile, updateMyProfile } from '../../../../services/profileService';
 
 interface EditProfileProps {
   desktop?: boolean;
 }
 
 const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
+  const { user, status } = useAuth();
+
   const [profileData, setProfileData] = useState({
-    name: 'Nombre usuario',
-    email: 'usuario@example.com'
+    name: '',
+    email: '',
+    phone: '',
   });
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
 
-  const handleInputChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setProfileData(prev => ({
-      ...prev,
-      [field]: e.target.value
-    }));
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      setLoadError(null);
+      setLoading(true);
+      try {
+        const profile = await fetchMyProfile();
+        if (!cancelled) {
+          setProfileData({
+            name: profile.name,
+            email: profile.email,
+            phone: profile.phone,
+          });
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError(e instanceof Error ? e.message : 'No se pudo cargar el perfil');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  const handleInputChange = useCallback((field: 'name' | 'email' | 'phone') => {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setProfileData((prev) => ({ ...prev, [field]: value }));
+      setSaveSuccess(false);
+    };
+  }, []);
+
+  const handleSubmit = async () => {
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const name = profileData.name.trim();
+    const email = profileData.email.trim();
+    const phone = profileData.phone.trim();
+
+    if (!name || !email) {
+      setSaveError('Nombre y correo son obligatorios');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const updated = await updateMyProfile({ name, email, phone });
+      setProfileData({
+        name: updated.name,
+        email: updated.email,
+        phone: updated.phone,
+      });
+      setSaveSuccess(true);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : 'No se pudo guardar');
+    } finally {
+      setSaving(false);
+    }
   };
 
-  const handleSubmit = () => {
-    console.log('Updating profile:', profileData);
-  };
+  const headerTitle = profileData.name.trim() || user?.username || 'Perfil';
+  const roleSubtitle =
+    user?.role === 'admin' ? 'Admin' : user?.role === 'seller' ? 'Vendedor' : 'Usuario';
 
   const content = (
     <div className={`edit-profile-container ${desktop ? 'desktop-edit-profile' : ''}`}>
-      {/* Desktop Header */}
       {desktop && (
         <div className="desktop-section-header">
           <h3>Modificar Perfil</h3>
         </div>
       )}
 
-      {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
+        <Header title={headerTitle} subtitle={roleSubtitle}>
+          <Link to="/Profile" aria-label="Cerrar">
+            <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round" />
+            </svg>
+          </Link>
         </Header>
       )}
 
-      {/* Mobile Title */}
       {!desktop && (
         <SectionTitle>
           <h2>Modificar perfil</h2>
         </SectionTitle>
       )}
 
-      {/* Form Fields */}
       <div className={`form-container ${desktop ? 'desktop-form' : ''}`}>
-        <h4 className="field-label">Nombre</h4>
-        <FormField
-          label="nombre"
-          value={profileData.name}
-          placeholder="Ej: Juan Perez"
-          editable={true}
-          onChange={handleInputChange('name')}
-        />
+        {loading ? (
+          <p className="profile-feedback">Cargando datos del perfil…</p>
+        ) : null}
 
-        <h4 className="field-label">Email</h4>
-        <FormField
-          label="email"
-          value={profileData.email}
-          placeholder="Ej: juanperez@example.com"
-          editable={true}
-          onChange={handleInputChange('email')}
-        />
+        {loadError ? (
+          <p className="profile-feedback profile-feedback--error" role="alert">
+            {loadError}
+          </p>
+        ) : null}
 
-        <div className="button-container">
-          <BtnBlue width="100%" height="3rem" onClick={handleSubmit}>
-            <span>Guardar cambios</span>
-          </BtnBlue>
-        </div>
+        {!loading && !loadError ? (
+          <>
+            <h4 className="field-label">Nombre</h4>
+            <FormField
+              label="nombre"
+              value={profileData.name}
+              placeholder="Ej: Juan Pérez"
+              editable={true}
+              onChange={handleInputChange('name')}
+            />
 
-        {/* Back Button mobile */}
-        {!desktop && (
+            <h4 className="field-label">Correo electrónico</h4>
+            <FormField
+              label="email"
+              value={profileData.email}
+              placeholder="Ej: juan@example.com"
+              editable={true}
+              onChange={handleInputChange('email')}
+            />
+
+            <h4 className="field-label">Teléfono</h4>
+            <FormField
+              label="teléfono"
+              value={profileData.phone}
+              placeholder="Ej: +54 11 1234-5678"
+              editable={true}
+              onChange={handleInputChange('phone')}
+            />
+
+            {saveError ? (
+              <p className="profile-feedback profile-feedback--error" role="alert">
+                {saveError}
+              </p>
+            ) : null}
+
+            {saveSuccess ? (
+              <p className="profile-feedback profile-feedback--success" role="status">
+                Cambios guardados correctamente.
+              </p>
+            ) : null}
+
+            <div className="button-container">
+              <BtnBlue width="100%" height="3rem" onClick={() => void handleSubmit()} disabled={saving}>
+                <span>{saving ? 'Guardando…' : 'Guardar cambios'}</span>
+              </BtnBlue>
+            </div>
+          </>
+        ) : null}
+
+        {!desktop ? (
           <Link to="/Profile" style={{ textDecoration: 'none', color: 'inherit' }}>
             <BtnBlue width="100%" height="3rem" isBackButton={true}>
               <span>Volver</span>
             </BtnBlue>
           </Link>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/Admin/mobile/Profile/Profile.css
+++ b/src/pages/Admin/mobile/Profile/Profile.css
@@ -61,3 +61,30 @@
 .edit-password-container {
   width: 100%;
 }
+
+.profile-feedback {
+  margin: 0.75rem 1rem 1rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.875rem;
+}
+
+.desktop-form .profile-feedback {
+  margin-left: 0;
+  color: var(--mainWhite);
+}
+
+.profile-feedback--error {
+  color: #b91c1c;
+}
+
+.desktop-form .profile-feedback--error {
+  color: #fca5a5;
+}
+
+.profile-feedback--success {
+  color: #15803d;
+}
+
+.desktop-form .profile-feedback--success {
+  color: #86efac;
+}

--- a/src/pages/Admin/mobile/Profile/Profile.tsx
+++ b/src/pages/Admin/mobile/Profile/Profile.tsx
@@ -3,13 +3,18 @@ import { Link } from "react-router-dom";
 import NavTo from "../../../../components/common/NavTo/NavTo";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import { LuUser } from "react-icons/lu";
+import { useAuth } from "../../../../context/AuthContext";
 
 const Profile = () => {
+  const { user } = useAuth();
+  const title = user?.username ?? "Perfil";
+  const subtitle =
+    user?.role === "admin" ? "Admin" : user?.role === "seller" ? "Vendedor" : "Usuario";
 
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header title={title} subtitle={subtitle}>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BtnBlue from '../../components/common/BtnBlue/BtnBlue';
-import { loginRequest } from '../../services/authService';
+import { useAuth } from '../../context/AuthContext';
 
 export default function LoginForm() {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -19,7 +20,7 @@ export default function LoginForm() {
     }
     setLoading(true);
     try {
-      await loginRequest(u, password);
+      await login(u, password);
       navigate('/', { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : 'No se pudo iniciar sesión');

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,17 +1,18 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getStoredToken } from '../../services/http';
+import { useAuth } from '../../context/AuthContext';
 import LoginForm from './LoginForm';
 import './Login.css';
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const { status } = useAuth();
 
   useEffect(() => {
-    if (getStoredToken()) {
+    if (status === 'authenticated') {
       navigate('/', { replace: true });
     }
-  }, [navigate]);
+  }, [navigate, status]);
 
   return (
     <div className="login-page">

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from '../config/api.config';
-import { setStoredToken } from './http';
+import { apiFetch, setStoredToken } from './http';
 
 export type LoginUser = {
   userId: number;
@@ -23,6 +23,17 @@ export async function loginRequest(username: string, password: string): Promise<
   const data = payload as { access_token: string; user: LoginUser };
   setStoredToken(data.access_token);
   return data;
+}
+
+export async function getCurrentUser(): Promise<LoginUser> {
+  const response = await apiFetch('/auth/me');
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error((payload as { message?: string }).message ?? 'No se pudo recuperar la sesión');
+  }
+
+  return payload as LoginUser;
 }
 
 export function logout(): void {

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from './http';
+
+/** Coincide con UserResponseDTO del backend (sin secretos). */
+export type UserProfile = {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  name: string;
+  phone: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type UpdateOwnProfilePayload = {
+  name?: string;
+  email?: string;
+  phone?: string;
+};
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === 'object') {
+    const message = (payload as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim()) return message;
+    if (Array.isArray(message) && message.length > 0 && typeof message[0] === 'string') {
+      return message[0];
+    }
+  }
+  return fallback;
+}
+
+export async function fetchMyProfile(): Promise<UserProfile> {
+  const response = await apiFetch('/users/me');
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(readErrorMessage(payload, 'No se pudo cargar el perfil'));
+  }
+
+  return payload as UserProfile;
+}
+
+export async function updateMyProfile(body: UpdateOwnProfilePayload): Promise<UserProfile> {
+  const response = await apiFetch('/users/me', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(readErrorMessage(payload, 'No se pudo guardar el perfil'));
+  }
+
+  return payload as UserProfile;
+}


### PR DESCRIPTION
Backend: agrega /auth/me y /users/me (GET/PATCH) para permitir recuperar y actualizar el perfil del usuario autenticado; agrega UpdateOwnProfileDto e implementa UsersService.updateOwnProfile con validación y verificaciones de conflictos; aplica RolesGuard a rutas de usuario solo para administradores.

Frontend: agrega AuthContext (AuthProvider + useAuth) y se integra en la aplicación principal; reemplaza las verificaciones directas de tokens con un flujo de autenticación consciente del contexto (inicio de sesión, cierre de sesión, actualización de sesión, getCurrentUser); actualiza Login, HeaderDesktop, Profile y EditProfile para usar AuthContext y llama a nuevos puntos finales de profileService; agrega profileService para obtener/actualizar /users/me y pequeñas mejoras de CSS/UX