### PR TITLE
Agrega confirmacion de logout y nombre de perfil, roles y slots en header

### DIFF
--- a/src/components/common/Header/Header.css
+++ b/src/components/common/Header/Header.css
@@ -1,20 +1,38 @@
 .header-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--header-side-width, 2.5rem) 1fr var(--header-side-width, 2.5rem);
   align-items: center;
-  justify-content: space-between;
+  column-gap: 0.35rem;
   margin-bottom: 1rem;
 }
 
-.icon-left,
-.icon-right {
-  flex: 0 0 auto;
+.header-side {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
   font-size: 1.5rem;
+}
+
+.header-side--start {
+  justify-self: start;
+}
+
+.header-side--end {
+  justify-self: end;
+}
+
+.header-side svg {
+  display: block;
+  flex-shrink: 0;
 }
 
 .header-text {
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-width: 0;
+  text-align: center;
 }
 
 .header-text .title {
@@ -24,4 +42,17 @@
 .header-text .subtitle {
   font-size: 0.85rem;
   color: #666;
+}
+
+.header-icon-button,
+.header-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import './Header.css';
+import { useAuth } from '../../../context/AuthContext';
+import { formatRoleSubtitle } from '../../../utils/roleLabel';
 
-interface HeaderProps {
-  title: string;
-  subtitle: string;
+export interface HeaderProps {
+  /**
+   * Título del encabezado. Si no se envía, se usa el nombre del perfil,
+   * el nombre de cuenta (username) o "Usuario".
+   */
+  title?: string;
+  /** Subtítulo. Si no se envía, se deriva del rol de la sesión. */
+  subtitle?: string;
   children: React.ReactNode;
 }
 
 const Header = ({ title, subtitle, children }: HeaderProps) => {
+  const { user, displayName } = useAuth();
+
+  const resolvedTitle =
+    title !== undefined
+      ? title
+      : displayName?.trim() || user?.username?.trim() || 'Usuario';
+
+  const resolvedSubtitle =
+    subtitle !== undefined ? subtitle : formatRoleSubtitle(user?.role);
+
   const childrenArray = React.Children.toArray(children);
   const [iconIzq, iconDer] = childrenArray;
 
@@ -15,14 +32,12 @@ const Header = ({ title, subtitle, children }: HeaderProps) => {
     <div className="header-container">
       <div className="icon-left">{iconIzq}</div>
       <div className="header-text">
-        <span className="title">{title}</span>
-        <span className="subtitle">{subtitle}</span>
+        <span className="title">{resolvedTitle}</span>
+        <span className="subtitle">{resolvedSubtitle}</span>
       </div>
       <div className="icon-right">{iconDer}</div>
     </div>
   );
 };
-
-
 
 export default Header;

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import './Header.css';
 import { useAuth } from '../../../context/AuthContext';
 import { formatRoleSubtitle } from '../../../utils/roleLabel';
@@ -11,31 +10,29 @@ export interface HeaderProps {
   title?: string;
   /** Subtítulo. Si no se envía, se deriva del rol de la sesión. */
   subtitle?: string;
-  children: React.ReactNode;
+  /** Contenido columna izquierda (icono atrás, cerrar sesión, etc.). */
+  leftSlot?: React.ReactNode;
+  /** Contenido columna derecha. */
+  rightSlot?: React.ReactNode;
 }
 
-const Header = ({ title, subtitle, children }: HeaderProps) => {
+const Header = ({ title, subtitle, leftSlot, rightSlot }: HeaderProps) => {
   const { user, displayName } = useAuth();
 
   const resolvedTitle =
-    title !== undefined
-      ? title
-      : displayName?.trim() || user?.username?.trim() || 'Usuario';
+    title !== undefined ? title : displayName?.trim() || user?.username?.trim() || 'Usuario';
 
   const resolvedSubtitle =
     subtitle !== undefined ? subtitle : formatRoleSubtitle(user?.role);
 
-  const childrenArray = React.Children.toArray(children);
-  const [iconIzq, iconDer] = childrenArray;
-
   return (
     <div className="header-container">
-      <div className="icon-left">{iconIzq}</div>
+      <div className="header-side header-side--start">{leftSlot}</div>
       <div className="header-text">
         <span className="title">{resolvedTitle}</span>
         <span className="subtitle">{resolvedSubtitle}</span>
       </div>
-      <div className="icon-right">{iconDer}</div>
+      <div className="header-side header-side--end">{rightSlot}</div>
     </div>
   );
 };

--- a/src/components/common/LogoutConfirmDialog/LogoutConfirmDialog.css
+++ b/src/components/common/LogoutConfirmDialog/LogoutConfirmDialog.css
@@ -1,0 +1,87 @@
+.logout-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.logout-confirm-panel {
+  width: 100%;
+  max-width: 420px;
+  background: #f7fafc;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  padding: 1.25rem;
+}
+
+.logout-confirm-title {
+  margin: 0;
+  font-size: 1rem;
+  color: #0d141c;
+}
+
+.logout-confirm-message {
+  margin: 0.75rem 0 0;
+  color: #4d7099;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.logout-confirm-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  align-items: center;
+}
+
+.logout-confirm-cancel {
+  flex: 1;
+  height: 3rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0d141c;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.logout-confirm-primary-wrap {
+  flex: 1;
+}
+
+/* --- Variante admin desktop (panel oscuro, coherente con header/sidebar) --- */
+
+.logout-confirm-overlay--desktop {
+  z-index: 2500;
+  backdrop-filter: blur(4px);
+}
+
+.logout-confirm-panel--desktop {
+  max-width: 440px;
+  background: linear-gradient(195deg, rgb(31, 41, 55), rgba(31, 41, 55, 0.96));
+  border: 1px solid rgba(100, 100, 100, 0.45);
+  box-shadow: rgba(0, 0, 0, 0.35) 0 1.25rem 1.75rem 0;
+}
+
+.logout-confirm-title--desktop {
+  color: rgb(233, 232, 232);
+}
+
+.logout-confirm-message--desktop {
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.logout-confirm-cancel--desktop {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgb(233, 232, 232);
+}
+
+.logout-confirm-cancel--desktop:hover {
+  background: rgba(255, 255, 255, 0.1);
+}

--- a/src/components/common/LogoutConfirmDialog/LogoutConfirmDialog.tsx
+++ b/src/components/common/LogoutConfirmDialog/LogoutConfirmDialog.tsx
@@ -1,0 +1,63 @@
+import BtnBlue from '../BtnBlue/BtnBlue';
+import './LogoutConfirmDialog.css';
+
+export type LogoutConfirmVariant = 'mobile' | 'desktop';
+
+export type LogoutConfirmDialogProps = {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  /** `desktop`: panel oscuro acorde al admin desktop. Por defecto `mobile`. */
+  variant?: LogoutConfirmVariant;
+};
+
+export function LogoutConfirmDialog({
+  open,
+  onCancel,
+  onConfirm,
+  variant = 'mobile',
+}: LogoutConfirmDialogProps) {
+  if (!open) return null;
+
+  const isDesktop = variant === 'desktop';
+
+  return (
+    <div
+      className={`logout-confirm-overlay${isDesktop ? ' logout-confirm-overlay--desktop' : ''}`}
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        className={`logout-confirm-panel${isDesktop ? ' logout-confirm-panel--desktop' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="logout-confirm-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="logout-confirm-title"
+          className={`logout-confirm-title${isDesktop ? ' logout-confirm-title--desktop' : ''}`}
+        >
+          Cerrar sesión
+        </h3>
+        <p className={`logout-confirm-message${isDesktop ? ' logout-confirm-message--desktop' : ''}`}>
+          ¿Desea cerrar sesión? Deberá volver a iniciar sesión para acceder al panel de administración.
+        </p>
+        <div className="logout-confirm-actions">
+          <button
+            type="button"
+            className={`logout-confirm-cancel${isDesktop ? ' logout-confirm-cancel--desktop' : ''}`}
+            onClick={onCancel}
+          >
+            Cancelar
+          </button>
+          <div className="logout-confirm-primary-wrap">
+            <BtnBlue width="100%" height="3rem" onClick={onConfirm}>
+              Cerrar sesión
+            </BtnBlue>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/Header/HeaderDesktop.css
+++ b/src/components/desktop/Header/HeaderDesktop.css
@@ -79,35 +79,37 @@
 .avatar-circle {
   width: 40px;
   height: 40px;
-  background-color: rgba(250, 250, 250, 0.226);
+  background-color: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--mainGray);
+  color: rgb(191, 219, 254);
 }
 
 .user-dropdown {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 0.35rem);
   right: 0;
-  background-color: rgba(150, 150, 150, 0.918);
-  border: 1px solid var(--mainGray);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  min-width: 180px;
+  background: linear-gradient(195deg, rgb(31, 41, 55), rgba(31, 41, 55, 0.98));
+  border: 1px solid rgba(100, 100, 100, 0.45);
+  border-radius: 10px;
+  box-shadow: rgba(0, 0, 0, 0.35) 0 0.75rem 1.5rem 0;
+  min-width: 200px;
   z-index: 1001;
   overflow: hidden;
+  padding: 0.25rem 0;
 }
 
 .dropdown-item {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 1rem;
   cursor: pointer;
-  transition: background-color 0.2s ease;
-  color: var(--mainBlack);
+  transition: background-color 0.15s ease, color 0.15s ease;
+  color: rgba(226, 232, 240, 0.95);
   font-family: 'Inter', sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
@@ -116,20 +118,22 @@
 }
 
 .dropdown-item:hover {
-  background-color: rgba(255, 255, 255, 0.25);
+  background-color: rgba(59, 130, 246, 0.12);
+  color: rgb(248, 250, 252);
 }
 
 .dropdown-item.logout {
-  color: #dc2626;
+  color: rgba(252, 165, 165, 0.95);
 }
 
 .dropdown-item.logout:hover {
-  background-color: rgba(220, 38, 38, 0.25);
+  background-color: rgba(220, 38, 38, 0.12);
+  color: rgb(254, 202, 202);
 }
 
 .dropdown-divider {
   height: 1px;
-  background-color: rgba(255, 255, 255, 0.2);
-  margin: 0;
-  width: 100%;
+  background-color: rgba(148, 163, 184, 0.22);
+  margin: 0.25rem 0.75rem;
+  width: auto;
 }

--- a/src/components/desktop/Header/HeaderDesktop.tsx
+++ b/src/components/desktop/Header/HeaderDesktop.tsx
@@ -10,7 +10,7 @@ import './HeaderDesktop.css';
 const HeaderDesktop = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, logout } = useAuth();
+  const { user, displayName, logout } = useAuth();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showCreateLinkPopup, setShowCreateLinkPopup] = useState(false);
   const [pendingOrdersCount, setPendingOrdersCount] = useState(0);
@@ -92,7 +92,9 @@ const HeaderDesktop = () => {
       </div>
 
       <div className="header-right">
-        <span className="header-right-text">Bienvenido, {user?.username ?? 'Usuario'}</span>
+        <span className="header-right-text">
+          Bienvenido, {displayName?.trim() || user?.username?.trim() || 'Usuario'}
+        </span>
         <div className="user-menu-container">
           <button 
             className="user-avatar"

--- a/src/components/desktop/Header/HeaderDesktop.tsx
+++ b/src/components/desktop/Header/HeaderDesktop.tsx
@@ -1,19 +1,37 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import BtnBlue from '../../common/BtnBlue/BtnBlue';
 import HeaderNotification from '../HeaderNotification/HeaderNotification';
 import CreateLink from '../../../pages/Admin/mobile/Orders/CreateLink';
 import { ordersService, OrderStatus } from '../../../services/ordersService';
 import { useAuth } from '../../../context/AuthContext';
+import { useLogoutConfirm } from '../../../hooks/useLogoutConfirm';
 import './HeaderDesktop.css';
 
 const HeaderDesktop = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, displayName, logout } = useAuth();
+  const { user, displayName } = useAuth();
+  const { requestLogout, logoutDialog } = useLogoutConfirm({
+    variant: 'desktop',
+    onConfirmed: () => navigate('/login', { replace: true }),
+  });
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showCreateLinkPopup, setShowCreateLinkPopup] = useState(false);
   const [pendingOrdersCount, setPendingOrdersCount] = useState(0);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showUserMenu) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      const root = userMenuRef.current;
+      if (root && !root.contains(e.target as Node)) {
+        setShowUserMenu(false);
+      }
+    };
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
+  }, [showUserMenu]);
 
   useEffect(() => {
     const fetchPendingCount = async () => {
@@ -48,10 +66,9 @@ const HeaderDesktop = () => {
     setShowCreateLinkPopup(false);
   };
 
-  const handleLogout = () => {
-    logout();
+  const handleLogoutClick = () => {
     setShowUserMenu(false);
-    navigate('/login');
+    requestLogout();
   };
 
   const handleProfile = () => {
@@ -95,7 +112,7 @@ const HeaderDesktop = () => {
         <span className="header-right-text">
           Bienvenido, {displayName?.trim() || user?.username?.trim() || 'Usuario'}
         </span>
-        <div className="user-menu-container">
+        <div className="user-menu-container" ref={userMenuRef}>
           <button 
             className="user-avatar"
             onClick={() => setShowUserMenu(!showUserMenu)}
@@ -120,7 +137,7 @@ const HeaderDesktop = () => {
               
               <div className="dropdown-divider"></div>
               
-              <div className="dropdown-item logout" onClick={handleLogout}>
+              <div className="dropdown-item logout" onClick={handleLogoutClick}>
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M17 7L15.59 8.41L18.17 11H8V13H18.17L15.59 15.59L17 17L22 12L17 7Z" fill="currentColor"/>
                   <path d="M4 5H12V3H4C2.9 3 2 3.9 2 5V19C2 20.1 2.9 21 4 21H12V19H4V5Z" fill="currentColor"/>
@@ -139,6 +156,7 @@ const HeaderDesktop = () => {
           onClose={handleCloseCreateLinkPopup}
         />
       )}
+      {logoutDialog}
     </header>
   );
 };

--- a/src/components/desktop/Sidebar/Sidebar.css
+++ b/src/components/desktop/Sidebar/Sidebar.css
@@ -62,6 +62,7 @@
   opacity: 1;
   background: transparent;
   color: rgb(233, 232, 232);
+  font: inherit;
   display: flex;
   align-items: center;
   width: 100%;

--- a/src/components/desktop/Sidebar/Sidebar.tsx
+++ b/src/components/desktop/Sidebar/Sidebar.tsx
@@ -1,20 +1,19 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import SidebarItem from './SidebarItem';
 import './Sidebar.css';
-import { 
-  LuClipboardList, 
-  LuUsers, 
-  LuBox, 
-  LuUserCog, 
+import {
+  LuClipboardList,
+  LuUsers,
+  LuBox,
+  LuUserCog,
   LuUser,
-  LuLogOut 
-} from "react-icons/lu";
+  LuLogOut,
+} from 'react-icons/lu';
+import { useLogoutConfirm } from '../../../hooks/useLogoutConfirm';
+import type { SidebarNavItem } from './SidebarItem';
 
-const Sidebar = () => {
-  const location = useLocation();
-
-  const menuItems = [
-    {
+const menuItems: SidebarNavItem[] = [
+  {
     id: 'orders',
     label: 'Pedidos',
     icon: LuClipboardList,
@@ -43,39 +42,45 @@ const Sidebar = () => {
     label: 'Perfil',
     icon: LuUser,
     path: '/Profile',
-  }/*,
-  {
-    id: 'reports',
-    label: 'Reportes',
-    icon: LuFileChartColumnIncreasing,
-    path: '/Reports',
-  }*/,
+  },
   {
     id: 'logout',
-    label: 'Cerrar Sesión',
+    label: 'Cerrar sesión',
     icon: LuLogOut,
     path: '',
   },
 ];
 
-  return (
-    <div className="sidebar">
-      <div className="sidebar-header">
-        <h2>Admin Panel</h2>
-      </div>
+const Sidebar = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { requestLogout, logoutDialog } = useLogoutConfirm({
+    variant: 'desktop',
+    onConfirmed: () => navigate('/login', { replace: true }),
+  });
 
-      <div className="sidebar-header-line" />
-      
-      <nav className="sidebar-nav">
-        {menuItems.map(item => (
-          <SidebarItem
-            key={item.id}
-            item={item}
-            isActive={location.pathname === item.path}
-          />
-        ))}
-      </nav>
-    </div>
+  return (
+    <>
+      <div className="sidebar">
+        <div className="sidebar-header">
+          <h2>Admin Panel</h2>
+        </div>
+
+        <div className="sidebar-header-line" />
+
+        <nav className="sidebar-nav">
+          {menuItems.map((item) => (
+            <SidebarItem
+              key={item.id}
+              item={item}
+              isActive={item.path !== '' && location.pathname === item.path}
+              onLogoutClick={item.id === 'logout' ? requestLogout : undefined}
+            />
+          ))}
+        </nav>
+      </div>
+      {logoutDialog}
+    </>
   );
 };
 

--- a/src/components/desktop/Sidebar/SidebarItem.tsx
+++ b/src/components/desktop/Sidebar/SidebarItem.tsx
@@ -1,26 +1,43 @@
 import { Link } from 'react-router-dom';
-import { IconType } from "react-icons";
+import type { IconType } from 'react-icons';
 import React from 'react';
 
-interface SidebarItemProps {
-  item: {
-    id: string;
-    label: string;
-    icon: IconType;
-    path: string;
-  };
-  isActive: boolean;
-}
+export type SidebarNavItem = {
+  id: string;
+  label: string;
+  icon: IconType;
+  path: string;
+};
 
-const SidebarItem = ({ item, isActive }: SidebarItemProps) => {
+type SidebarItemProps = {
+  item: SidebarNavItem;
+  isActive: boolean;
+  /** Si está definido y el ítem es `logout`, se usa botón en lugar de `Link`. */
+  onLogoutClick?: () => void;
+};
+
+const SidebarItem = ({ item, isActive, onLogoutClick }: SidebarItemProps) => {
+  const content = (
+    <>
+      <span className="sidebar-item-icon">{React.createElement(item.icon)}</span>
+      <span className="sidebar-item-label">{item.label}</span>
+    </>
+  );
+
+  if (item.id === 'logout' && onLogoutClick) {
+    return (
+      <div className={`sidebar-item ${isActive ? 'active' : ''}`}>
+        <button type="button" className="sidebar-item-link" onClick={onLogoutClick}>
+          {content}
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className={`sidebar-item ${isActive ? 'active' : ''}`}>
-      <Link 
-        to={item.path} 
-        className="sidebar-item-link"
-      >
-        <span className="sidebar-item-icon">{React.createElement(item.icon)}</span>
-        <span className="sidebar-item-label">{item.label}</span>
+      <Link to={item.path} className="sidebar-item-link">
+        {content}
       </Link>
     </div>
   );

--- a/src/components/mobile/header/CartHeaderIcon.tsx
+++ b/src/components/mobile/header/CartHeaderIcon.tsx
@@ -1,0 +1,25 @@
+/** Icono de carrito usado en el header del portal cliente (p. ej. Cart). */
+export function CartHeaderIcon() {
+  return (
+    <svg
+      width={36}
+      height={36}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path
+        d="M3 3h2.4l1.8 9.6a2 2 0 0 0 2 1.6h7.4a1.6 1.6 0 0 0 1.6-1.2L21 6H6.8"
+        stroke="#000"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="10.5" cy="19" r="1.4" stroke="#000" strokeWidth="1.2" fill="none" />
+      <circle cx="18.5" cy="19" r="1.4" stroke="#000" strokeWidth="1.2" fill="none" />
+      <line x1="10.5" y1="17.6" x2="10.5" y2="14.2" stroke="#000" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="10.5" y1="17.6" x2="18.5" y2="17.6" stroke="#000" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/components/mobile/header/CustomerOrderSummaryHeaderIcon.tsx
+++ b/src/components/mobile/header/CustomerOrderSummaryHeaderIcon.tsx
@@ -1,0 +1,20 @@
+/** Icono de resumen de pedido usado en headers del portal cliente (mobile). */
+export function CustomerOrderSummaryHeaderIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 20 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M18.25 0.75H1.75C0.921573 0.75 0.25 1.42157 0.25 2.25V15.75C0.25 16.5784 0.921573 17.25 1.75 17.25H18.25C19.0784 17.25 19.75 16.5784 19.75 15.75V2.25C19.75 1.42157 19.0784 0.75 18.25 0.75ZM18.25 15.75H1.75V2.25H18.25V15.75ZM14.5 5.25C14.5 7.73528 12.4853 9.75 10 9.75C7.51472 9.75 5.5 7.73528 5.5 5.25C5.5 4.83579 5.83579 4.5 6.25 4.5C6.66421 4.5 7 4.83579 7 5.25C7 6.90685 8.34315 8.25 10 8.25C11.6569 8.25 13 6.90685 13 5.25C13 4.83579 13.3358 4.5 13.75 4.5C14.1642 4.5 14.5 4.83579 14.5 5.25Z"
+        fill="#0D141C"
+      />
+    </svg>
+  );
+}

--- a/src/components/mobile/header/HeaderBackNavLink.tsx
+++ b/src/components/mobile/header/HeaderBackNavLink.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+import { HeaderBackArrowIcon } from './MobileHeaderIcons';
+
+type HeaderBackNavLinkProps = {
+  to: string;
+  ariaLabel?: string;
+};
+
+export function HeaderBackNavLink({ to, ariaLabel = 'Volver' }: HeaderBackNavLinkProps) {
+  return (
+    <Link to={to} aria-label={ariaLabel} className="header-icon-link">
+      <HeaderBackArrowIcon width={24} height={24} />
+    </Link>
+  );
+}

--- a/src/components/mobile/header/MobileHeaderIcons.tsx
+++ b/src/components/mobile/header/MobileHeaderIcons.tsx
@@ -1,0 +1,45 @@
+import type { SVGProps } from 'react';
+
+export function HeaderCloseIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      {...props}
+    >
+      <path
+        d="M3 3L13 13M13 3L3 13"
+        stroke="#0D141C"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function HeaderBackArrowIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      {...props}
+    >
+      <path
+        d="M9.5 3.5L5 8L9.5 12.5"
+        stroke="#0D141C"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M5 8H14" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,32 +1,54 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { getCurrentUser, loginRequest, logout as authLogout, type LoginUser } from '../services/authService';
 import { getStoredToken } from '../services/http';
+import { fetchMyProfile } from '../services/profileService';
 
 type AuthStatus = 'loading' | 'authenticated' | 'anonymous';
 
 type AuthContextValue = {
   user: LoginUser | null;
+  /** Nombre para mostrar desde `/users/me`; null si aún no cargó o falló (no rompe la sesión). */
+  displayName: string | null;
   status: AuthStatus;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
   refreshSession: () => Promise<void>;
+  /** Vuelve a leer el nombre del perfil (p. ej. tras guardar en Editar perfil). */
+  refreshDisplayProfile: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<LoginUser | null>(null);
+  const [displayName, setDisplayName] = useState<string | null>(null);
   const [status, setStatus] = useState<AuthStatus>('loading');
+
+  const refreshDisplayProfile = useCallback(async () => {
+    if (!getStoredToken()) {
+      setDisplayName(null);
+      return;
+    }
+    try {
+      const profile = await fetchMyProfile();
+      const trimmed = profile.name?.trim();
+      setDisplayName(trimmed || null);
+    } catch {
+      setDisplayName(null);
+    }
+  }, []);
 
   const logout = useCallback(() => {
     authLogout();
     setUser(null);
+    setDisplayName(null);
     setStatus('anonymous');
   }, []);
 
   const refreshSession = useCallback(async () => {
     if (!getStoredToken()) {
       setUser(null);
+      setDisplayName(null);
       setStatus('anonymous');
       return;
     }
@@ -35,18 +57,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const currentUser = await getCurrentUser();
       setUser(currentUser);
       setStatus('authenticated');
+      void refreshDisplayProfile();
     } catch {
       authLogout();
       setUser(null);
+      setDisplayName(null);
       setStatus('anonymous');
     }
-  }, []);
+  }, [refreshDisplayProfile]);
 
-  const login = useCallback(async (username: string, password: string) => {
-    const { user: loggedInUser } = await loginRequest(username, password);
-    setUser(loggedInUser);
-    setStatus('authenticated');
-  }, []);
+  const login = useCallback(
+    async (username: string, password: string) => {
+      const { user: loggedInUser } = await loginRequest(username, password);
+      setUser(loggedInUser);
+      setStatus('authenticated');
+      void refreshDisplayProfile();
+    },
+    [refreshDisplayProfile],
+  );
 
   useEffect(() => {
     void refreshSession();
@@ -55,12 +83,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
+      displayName,
       status,
       login,
       logout,
       refreshSession,
+      refreshDisplayProfile,
     }),
-    [user, status, login, logout, refreshSession],
+    [user, displayName, status, login, logout, refreshSession, refreshDisplayProfile],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/useLogoutConfirm.tsx
+++ b/src/hooks/useLogoutConfirm.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import {
+  LogoutConfirmDialog,
+  type LogoutConfirmVariant,
+} from '../components/common/LogoutConfirmDialog/LogoutConfirmDialog';
+
+export type UseLogoutConfirmOptions = {
+  variant?: LogoutConfirmVariant;
+  /** Tras cerrar sesión (p. ej. `navigate('/login', { replace: true })`). */
+  onConfirmed?: () => void;
+};
+
+export function useLogoutConfirm(options?: UseLogoutConfirmOptions) {
+  const [open, setOpen] = useState(false);
+  const { logout } = useAuth();
+  const variant = options?.variant ?? 'mobile';
+  const onConfirmed = options?.onConfirmed;
+
+  const requestLogout = useCallback(() => setOpen(true), []);
+
+  const confirmLogout = useCallback(() => {
+    logout();
+    setOpen(false);
+    onConfirmed?.();
+  }, [logout, onConfirmed]);
+
+  const cancelLogout = useCallback(() => setOpen(false), []);
+
+  const logoutDialog = (
+    <LogoutConfirmDialog
+      open={open}
+      variant={variant}
+      onCancel={cancelLogout}
+      onConfirm={confirmLogout}
+    />
+  );
+
+  return { requestLogout, logoutDialog };
+}

--- a/src/pages/Admin/mobile/Manage/Clients/AddClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/AddClients.tsx
@@ -232,7 +232,7 @@ const AddClients: React.FC<AddClientsProps> = ({ desktop = false, onClose, onCli
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Clients/AddClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/AddClients.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -232,12 +233,10 @@ const AddClients: React.FC<AddClientsProps> = ({ desktop = false, onClose, onCli
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/ClientsList" ariaLabel="Volver a la lista de clientes" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {/* Mobile Title */}

--- a/src/pages/Admin/mobile/Manage/Clients/AdminClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/AdminClients.tsx
@@ -1,4 +1,5 @@
-﻿import Header from "../../../../../components/common/Header/Header"
+import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../../components/common/NavTo/NavTo";
@@ -9,12 +10,10 @@ const AdminClients = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage" ariaLabel="Volver a administrar" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Manage/Clients/AdminClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/AdminClients.tsx
@@ -9,7 +9,7 @@ const AdminClients = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Clients/ClientsList.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/ClientsList.tsx
@@ -70,7 +70,7 @@ const ClientsList = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Clients/ClientsList.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/ClientsList.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -70,12 +71,10 @@ const ClientsList = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage/AdminClients" ariaLabel="Volver a clientes" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Title */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/src/pages/Admin/mobile/Manage/Clients/EditClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/EditClients.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -295,12 +296,10 @@ const EditClients: React.FC<EditClientsProps> = ({ desktop = false, onClose, cli
       )}
 
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/ClientsList" ariaLabel="Volver a la lista de clientes" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {!desktop && (

--- a/src/pages/Admin/mobile/Manage/Clients/EditClients.tsx
+++ b/src/pages/Admin/mobile/Manage/Clients/EditClients.tsx
@@ -295,7 +295,7 @@ const EditClients: React.FC<EditClientsProps> = ({ desktop = false, onClose, cli
       )}
 
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Manage.tsx
+++ b/src/pages/Admin/mobile/Manage/Manage.tsx
@@ -1,19 +1,25 @@
-﻿import Header from "../../../../components/common/Header/Header"
+import Header from "../../../../components/common/Header/Header"
+import { useLogoutConfirm } from "../../../../hooks/useLogoutConfirm";
+import { HeaderCloseIcon } from "../../../../components/mobile/header/MobileHeaderIcons";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../components/common/NavTo/NavTo";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 
 const Manage = () => {
+  const { requestLogout, logoutDialog } = useLogoutConfirm();
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={
+          <button type="button" className="header-icon-button" onClick={requestLogout} aria-label="Cerrar sesión">
+            <HeaderCloseIcon width={24} height={24} />
+          </button>
+        }
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
+      {logoutDialog}
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Manage/Manage.tsx
+++ b/src/pages/Admin/mobile/Manage/Manage.tsx
@@ -8,7 +8,7 @@ const Manage = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/OrderHistory.tsx
+++ b/src/pages/Admin/mobile/Manage/OrderHistory.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Header from "../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue";
@@ -130,12 +131,10 @@ const OrderHistory = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage" ariaLabel="Volver a administrar" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Manage/OrderHistory.tsx
+++ b/src/pages/Admin/mobile/Manage/OrderHistory.tsx
@@ -130,7 +130,7 @@ const OrderHistory = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Products/AddProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/AddProducts.tsx
@@ -205,7 +205,7 @@ const AddProducts: React.FC<AddProductsProps> = ({ desktop = false, onClose, onP
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Products/AddProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/AddProducts.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -205,12 +206,10 @@ const AddProducts: React.FC<AddProductsProps> = ({ desktop = false, onClose, onP
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/ProductsList" ariaLabel="Volver a la lista de productos" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {/* Mobile Title */}

--- a/src/pages/Admin/mobile/Manage/Products/AdminProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/AdminProducts.tsx
@@ -9,7 +9,7 @@ const AdminProducts = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Products/AdminProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/AdminProducts.tsx
@@ -1,4 +1,5 @@
-﻿import Header from "../../../../../components/common/Header/Header"
+import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../../components/common/NavTo/NavTo";
@@ -9,12 +10,10 @@ const AdminProducts = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage" ariaLabel="Volver a administrar" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Manage/Products/EditProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/EditProducts.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -183,12 +184,10 @@ const EditProducts: React.FC<EditProductsProps> = ({ desktop = false, onClose, p
       )}
 
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/ProductsList" ariaLabel="Volver a la lista de productos" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {!desktop && (

--- a/src/pages/Admin/mobile/Manage/Products/EditProducts.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/EditProducts.tsx
@@ -183,7 +183,7 @@ const EditProducts: React.FC<EditProductsProps> = ({ desktop = false, onClose, p
       )}
 
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Products/ProductsList.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/ProductsList.tsx
@@ -69,7 +69,7 @@ const ProductsList = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Products/ProductsList.tsx
+++ b/src/pages/Admin/mobile/Manage/Products/ProductsList.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -69,12 +70,10 @@ const ProductsList = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage/AdminProducts" ariaLabel="Volver a productos" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Title */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/src/pages/Admin/mobile/Manage/Sellers/AddSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/AddSellers.tsx
@@ -120,7 +120,7 @@ const AddSellers: React.FC<AddSellersProps> = ({ desktop = false, onClose, onSel
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Sellers/AddSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/AddSellers.tsx
@@ -1,4 +1,5 @@
-﻿import Header from "../../../../../components/common/Header/Header"
+import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -120,12 +121,10 @@ const AddSellers: React.FC<AddSellersProps> = ({ desktop = false, onClose, onSel
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/SellersList" ariaLabel="Volver a la lista de vendedores" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {/* Mobile Title */}

--- a/src/pages/Admin/mobile/Manage/Sellers/AdminSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/AdminSellers.tsx
@@ -1,4 +1,5 @@
-﻿import Header from "../../../../../components/common/Header/Header"
+import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../../components/common/NavTo/NavTo";
@@ -9,12 +10,10 @@ const AdminSellers = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage" ariaLabel="Volver a administrar" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Manage/Sellers/AdminSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/AdminSellers.tsx
@@ -9,7 +9,7 @@ const AdminSellers = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Sellers/EditSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/EditSellers.tsx
@@ -152,7 +152,7 @@ const EditSellers: React.FC<EditSellersProps> = ({ desktop = false, onClose, sel
       )}
 
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Manage/Sellers/EditSellers.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/EditSellers.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -152,12 +153,10 @@ const EditSellers: React.FC<EditSellersProps> = ({ desktop = false, onClose, sel
       )}
 
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LiaToolsSolid fontSize={"1.75rem"}/>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Manage/SellersList" ariaLabel="Volver a la lista de vendedores" />}
+          rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+        />
       )}
 
       {!desktop && (

--- a/src/pages/Admin/mobile/Manage/Sellers/SellersList.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/SellersList.tsx
@@ -67,7 +67,7 @@ const SellersList = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Manage/Sellers/SellersList.tsx
+++ b/src/pages/Admin/mobile/Manage/Sellers/SellersList.tsx
@@ -1,4 +1,5 @@
 import Header from "../../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../../components/mobile/header/HeaderBackNavLink";
 import { LiaToolsSolid } from "react-icons/lia";
 import { Link } from "react-router-dom";
 import SectionTitle from "../../../../../components/common/SectionTitle/SectionTitle";
@@ -67,12 +68,10 @@ const SellersList = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LiaToolsSolid fontSize={"1.75rem"}/>
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage/AdminSellers" ariaLabel="Volver a vendedores" />}
+        rightSlot={<LiaToolsSolid fontSize={"1.75rem"} />}
+      />
 
       {/* Title */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/src/pages/Admin/mobile/Orders/CreateLink.tsx
+++ b/src/pages/Admin/mobile/Orders/CreateLink.tsx
@@ -280,7 +280,7 @@ const CreateLink: React.FC<CreateLinkProps> = ({ desktop = false, onClose }) => 
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Orders/CreateLink.tsx
+++ b/src/pages/Admin/mobile/Orders/CreateLink.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 import Header from "../../../../components/common/Header/Header";
+import { useLogoutConfirm } from "../../../../hooks/useLogoutConfirm";
+import { HeaderCloseIcon } from "../../../../components/mobile/header/MobileHeaderIcons";
 import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue"
 import { LuClipboardList } from "react-icons/lu";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
@@ -16,6 +18,7 @@ interface CreateLinkProps {
 }
 
 const CreateLink: React.FC<CreateLinkProps> = ({ desktop = false, onClose }) => {
+  const { requestLogout, logoutDialog } = useLogoutConfirm();
   const [clientData, setClientData] = useState({
     name: '',
     email: '',
@@ -280,12 +283,14 @@ const CreateLink: React.FC<CreateLinkProps> = ({ desktop = false, onClose }) => 
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-          <LuClipboardList />
-        </Header>
+        <Header
+          leftSlot={
+            <button type="button" className="header-icon-button" onClick={requestLogout} aria-label="Cerrar sesión">
+              <HeaderCloseIcon width={24} height={24} />
+            </button>
+          }
+          rightSlot={<LuClipboardList />}
+        />
       )}
 
       {/* Mobile Title */}
@@ -625,6 +630,7 @@ const CreateLink: React.FC<CreateLinkProps> = ({ desktop = false, onClose }) => 
           </div>
         )}
       </div>
+      {logoutDialog}
     </>
   );
 

--- a/src/pages/Admin/mobile/Orders/Orders.tsx
+++ b/src/pages/Admin/mobile/Orders/Orders.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import Header from "../../../../components/common/Header/Header";
 import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue"
 import { LuClipboardList } from "react-icons/lu";
+import { useLogoutConfirm } from "../../../../hooks/useLogoutConfirm";
+import { HeaderCloseIcon } from "../../../../components/mobile/header/MobileHeaderIcons";
 import { Link } from "react-router-dom";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import InfoRow from '../../../../components/common/InfoRow/InfoRow';
@@ -10,6 +12,7 @@ import SearchBar from '../../../../components/common/SearchBar/SearchBar';
 import { ordersService, Order, OrderStatus } from "../../../../services/ordersService";
 
 const Orders = () => {
+  const { requestLogout, logoutDialog } = useLogoutConfirm();
   const navigate = useNavigate();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
@@ -74,12 +77,15 @@ const Orders = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LuClipboardList />
-      </Header>
+      <Header
+        leftSlot={
+          <button type="button" className="header-icon-button" onClick={requestLogout} aria-label="Cerrar sesión">
+            <HeaderCloseIcon width={24} height={24} />
+          </button>
+        }
+        rightSlot={<LuClipboardList />}
+      />
+      {logoutDialog}
 
       {/* Orders Title */}
       <SectionTitle>

--- a/src/pages/Admin/mobile/Orders/Orders.tsx
+++ b/src/pages/Admin/mobile/Orders/Orders.tsx
@@ -74,7 +74,7 @@ const Orders = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Orders/ValidateOrder.tsx
+++ b/src/pages/Admin/mobile/Orders/ValidateOrder.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import Header from "../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../components/mobile/header/HeaderBackNavLink";
 import { LuClipboardList } from "react-icons/lu";
 import ProductList from "../../../../components/common/ProductList/ProductList";
 import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue";
@@ -392,20 +393,9 @@ const ValidateOrder = () => {
       <Header 
         title={formatOrderNumber(order.id)} 
         subtitle={formatDate(order.createdAt)}
-      >
-        <svg 
-          width="24" 
-          height="24" 
-          viewBox="0 0 16 16" 
-          fill="none" 
-          xmlns="http://www.w3.org/2000/svg"
-          onClick={() => navigate('/Orders')}
-          style={{ cursor: 'pointer' }}
-        >
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LuClipboardList />
-      </Header>
+        leftSlot={<HeaderBackNavLink to="/Orders" ariaLabel="Volver a pedidos" />}
+        rightSlot={<LuClipboardList />}
+      />
 
       {/* Error Message */}
       {error && (

--- a/src/pages/Admin/mobile/Profile/EditPassword.tsx
+++ b/src/pages/Admin/mobile/Profile/EditPassword.tsx
@@ -60,7 +60,7 @@ const EditPassword: React.FC<EditPasswordProps> = ({ desktop = false }) => {
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header title="Nombre usuario" subtitle="Admin">
+        <Header>
           <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
           </svg>

--- a/src/pages/Admin/mobile/Profile/EditPassword.tsx
+++ b/src/pages/Admin/mobile/Profile/EditPassword.tsx
@@ -1,4 +1,6 @@
-﻿import Header from "../../../../components/common/Header/Header";
+import Header from "../../../../components/common/Header/Header";
+import { HeaderBackNavLink } from "../../../../components/mobile/header/HeaderBackNavLink";
+import { LuUser } from "react-icons/lu";
 import { Link } from "react-router-dom";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import BtnBlue from "../../../../components/common/BtnBlue/BtnBlue";
@@ -60,11 +62,10 @@ const EditPassword: React.FC<EditPasswordProps> = ({ desktop = false }) => {
 
       {/* Mobile Header */}
       {!desktop && (
-        <Header>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-        </Header>
+        <Header
+          leftSlot={<HeaderBackNavLink to="/Profile" ariaLabel="Volver al perfil" />}
+          rightSlot={<LuUser />}
+        />
       )}
 
       {/* Mobile Title */}

--- a/src/pages/Admin/mobile/Profile/EditProfile.tsx
+++ b/src/pages/Admin/mobile/Profile/EditProfile.tsx
@@ -13,7 +13,7 @@ interface EditProfileProps {
 }
 
 const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
-  const { user, status } = useAuth();
+  const { status, refreshDisplayProfile } = useAuth();
 
   const [profileData, setProfileData] = useState({
     name: '',
@@ -91,6 +91,7 @@ const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
         email: updated.email,
         phone: updated.phone,
       });
+      await refreshDisplayProfile();
       setSaveSuccess(true);
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : 'No se pudo guardar');
@@ -99,9 +100,7 @@ const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
     }
   };
 
-  const headerTitle = profileData.name.trim() || user?.username || 'Perfil';
-  const roleSubtitle =
-    user?.role === 'admin' ? 'Admin' : user?.role === 'seller' ? 'Vendedor' : 'Usuario';
+  const headerTitleOverride = profileData.name.trim() || undefined;
 
   const content = (
     <div className={`edit-profile-container ${desktop ? 'desktop-edit-profile' : ''}`}>
@@ -112,7 +111,7 @@ const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
       )}
 
       {!desktop && (
-        <Header title={headerTitle} subtitle={roleSubtitle}>
+        <Header title={headerTitleOverride}>
           <Link to="/Profile" aria-label="Cerrar">
             <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round" />

--- a/src/pages/Admin/mobile/Profile/EditProfile.tsx
+++ b/src/pages/Admin/mobile/Profile/EditProfile.tsx
@@ -1,4 +1,6 @@
-﻿import Header from '../../../../components/common/Header/Header';
+import Header from '../../../../components/common/Header/Header';
+import { HeaderBackNavLink } from '../../../../components/mobile/header/HeaderBackNavLink';
+import { LuUser } from 'react-icons/lu';
 import { Link } from 'react-router-dom';
 import SectionTitle from '../../../../components/common/SectionTitle/SectionTitle';
 import BtnBlue from '../../../../components/common/BtnBlue/BtnBlue';
@@ -111,13 +113,11 @@ const EditProfile: React.FC<EditProfileProps> = ({ desktop = false }) => {
       )}
 
       {!desktop && (
-        <Header title={headerTitleOverride}>
-          <Link to="/Profile" aria-label="Cerrar">
-            <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round" />
-            </svg>
-          </Link>
-        </Header>
+        <Header
+          title={headerTitleOverride}
+          leftSlot={<HeaderBackNavLink to="/Profile" ariaLabel="Volver al perfil" />}
+          rightSlot={<LuUser />}
+        />
       )}
 
       {!desktop && (

--- a/src/pages/Admin/mobile/Profile/Profile.css
+++ b/src/pages/Admin/mobile/Profile/Profile.css
@@ -88,3 +88,30 @@
 .desktop-form .profile-feedback--success {
   color: #86efac;
 }
+
+/* Hub Perfil (mobile): enlaces y fila de cerrar sesión */
+.profile-options-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.profile-logout-row {
+  width: 100%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  color: #b71010;
+  font-weight: 500;
+  text-align: left;
+}
+
+.profile-logout-row__label {
+  margin: 0;
+}
+
+.profile-logout-row__icon {
+  font-size: 1.5rem;
+}

--- a/src/pages/Admin/mobile/Profile/Profile.tsx
+++ b/src/pages/Admin/mobile/Profile/Profile.tsx
@@ -3,18 +3,12 @@ import { Link } from "react-router-dom";
 import NavTo from "../../../../components/common/NavTo/NavTo";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
 import { LuUser } from "react-icons/lu";
-import { useAuth } from "../../../../context/AuthContext";
 
 const Profile = () => {
-  const { user } = useAuth();
-  const title = user?.username ?? "Perfil";
-  const subtitle =
-    user?.role === "admin" ? "Admin" : user?.role === "seller" ? "Vendedor" : "Usuario";
-
   return (
     <>
       {/* Header */}  
-      <Header title={title} subtitle={subtitle}>
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Profile/Profile.tsx
+++ b/src/pages/Admin/mobile/Profile/Profile.tsx
@@ -1,19 +1,28 @@
-﻿import Header from "../../../../components/common/Header/Header"
+import Header from "../../../../components/common/Header/Header";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../components/common/NavTo/NavTo";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
-import { LuUser } from "react-icons/lu";
+import { LuUser, LuLogOut } from "react-icons/lu";
+import { useLogoutConfirm } from "../../../../hooks/useLogoutConfirm";
+import { HeaderCloseIcon } from "../../../../components/mobile/header/MobileHeaderIcons";
+import "../../../../components/common/NavTo/NavTo.css";
+import "./Profile.css";
 
 const Profile = () => {
+  const { requestLogout, logoutDialog } = useLogoutConfirm();
+
   return (
     <>
-      {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LuUser />
-      </Header>
+      {/* Header */}
+      <Header
+        leftSlot={
+          <button type="button" className="header-icon-button" onClick={requestLogout} aria-label="Cerrar sesión">
+            <HeaderCloseIcon width={24} height={24} />
+          </button>
+        }
+        rightSlot={<LuUser />}
+      />
+      {logoutDialog}
 
       {/* Manage Title */}
       <SectionTitle>
@@ -21,14 +30,22 @@ const Profile = () => {
       </SectionTitle>
 
       {/* Manage Options */}
-      <Link to="/Profile/EditProfile" style={{ textDecoration: 'none', color: 'inherit' }}>
+      <Link to="/Profile/EditProfile" className="profile-options-link">
         <NavTo text="Modificar datos de perfil" />
       </Link>
-      <Link to="/Profile/EditPassword" style={{ textDecoration: 'none', color: 'inherit' }}>
+      <Link to="/Profile/EditPassword" className="profile-options-link">
         <NavTo text="Modificar contraseña" />
       </Link>
+      <button
+        type="button"
+        className="navto-container profile-logout-row"
+        onClick={requestLogout}
+      >
+        <p className="profile-logout-row__label">Cerrar sesión</p>
+        <LuLogOut className="profile-logout-row__icon" aria-hidden />
+      </button>
     </>
-  )
-}
+  );
+};
 
-export default Profile
+export default Profile;

--- a/src/pages/Admin/mobile/Reports/Reports.tsx
+++ b/src/pages/Admin/mobile/Reports/Reports.tsx
@@ -8,7 +8,7 @@ const Reports = () => {
   return (
     <>
       {/* Header */}  
-      <Header title="Nombre usuario" subtitle="Admin">
+      <Header>
         <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
         </svg>

--- a/src/pages/Admin/mobile/Reports/Reports.tsx
+++ b/src/pages/Admin/mobile/Reports/Reports.tsx
@@ -1,4 +1,5 @@
-﻿import Header from "../../../../components/common/Header/Header"
+import Header from "../../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../../components/mobile/header/HeaderBackNavLink";
 import { Link } from "react-router-dom";
 import NavTo from "../../../../components/common/NavTo/NavTo";
 import SectionTitle from "../../../../components/common/SectionTitle/SectionTitle";
@@ -8,12 +9,10 @@ const Reports = () => {
   return (
     <>
       {/* Header */}  
-      <Header>
-        <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-        <LuFileChartColumnIncreasing />
-      </Header>
+      <Header
+        leftSlot={<HeaderBackNavLink to="/Manage" ariaLabel="Volver a administrar" />}
+        rightSlot={<LuFileChartColumnIncreasing />}
+      />
 
       {/* Manage Title */}
       <SectionTitle>

--- a/src/pages/Customer/desktop/CustomerDesktop.css
+++ b/src/pages/Customer/desktop/CustomerDesktop.css
@@ -4,6 +4,18 @@
   background: #f5f7fb;
 }
 
+/* Header compartido: aire superior y misma columna que el contenido */
+.customer-desktop > .header-container {
+  margin-top: 1.25rem;
+  max-width: 1440px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  box-sizing: border-box;
+}
+
 .customer-desktop-content {
   display: grid;
   grid-template-columns: 2fr 1.3fr;

--- a/src/pages/Customer/desktop/CustomerDesktop.tsx
+++ b/src/pages/Customer/desktop/CustomerDesktop.tsx
@@ -351,10 +351,7 @@ const CustomerDesktop = () => {
 
   return (
     <div className="customer-desktop">
-      <Header title={orderNumber || 'Pedido'} subtitle={orderDate || ''}>
-        <span />
-        <span />
-      </Header>
+      <Header title={orderNumber || 'Pedido'} subtitle={orderDate || ''} />
 
       <div className="customer-desktop-timer-row">
         <span className="customer-desktop-timer">

--- a/src/pages/Customer/mobile/Cart.tsx
+++ b/src/pages/Customer/mobile/Cart.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useSearchParams, Link, useNavigate } from 'react-router-dom'
 import Header from "../../../components/common/Header/Header"
+import { HeaderBackNavLink } from "../../../components/mobile/header/HeaderBackNavLink";
+import { CartHeaderIcon } from '../../../components/mobile/header/CartHeaderIcon';
 import SectionTitle from "../../../components/common/SectionTitle/SectionTitle"
 import ProductList from "../../../components/common/ProductList/ProductList"
 import BtnBlue from "../../../components/common/BtnBlue/BtnBlue"
@@ -211,35 +213,17 @@ const Cart = () => {
   return (
     <>
       {/* Header */}        
-      <Header title={orderNumber || 'Pedido'} subtitle={orderDate || ''}>
-        <Link 
-          to={`/NewOrder${token ? `?token=${token}` : ''}`} 
-          style={{ textDecoration: 'none', color: 'inherit', display: 'flex', alignItems: 'center' }}
-        >
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9.5 3.5L5 8L9.5 12.5" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M5 8H14" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-        </Link>
-
-        <svg width="36" height="36" viewBox="0 0 24 24" fill="none"
-          xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img">
-          {/* Cuerpo del carrito */}
-          <path d="M3 3h2.4l1.8 9.6a2 2 0 0 0 2 1.6h7.4a1.6 1.6 0 0 0 1.6-1.2L21 6H6.8"
-            stroke="#000" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-
-          {/* Ruedas */}
-          <circle cx="10.5" cy="19" r="1.4" stroke="#000" strokeWidth="1.2" fill="none"/>
-          <circle cx="18.5" cy="19" r="1.4" stroke="#000" strokeWidth="1.2" fill="none"/>
-
-          {/* Conexion rueda trasera a carro */}
-          <line x1="10.5" y1="17.6" x2="10.5" y2="14.2" stroke="#000" strokeWidth="1.2" strokeLinecap="round"/>
-
-          {/* Conexion entre ruedas */}
-          <line x1="10.5" y1="17.6" x2="18.5" y2="17.6" stroke="#000" strokeWidth="1.2" strokeLinecap="round"/>
-        </svg>
-
-      </Header>
+      <Header
+        title={orderNumber || 'Pedido'}
+        subtitle={orderDate || ''}
+        leftSlot={
+          <HeaderBackNavLink
+            to={`/NewOrder${token ? `?token=${token}` : ''}`}
+            ariaLabel="Volver al pedido"
+          />
+        }
+        rightSlot={<CartHeaderIcon />}
+      />
       
       {/* Orders Title */}
       <SectionTitle>

--- a/src/pages/Customer/mobile/CustomerOrderHistory.tsx
+++ b/src/pages/Customer/mobile/CustomerOrderHistory.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import Header from "../../../components/common/Header/Header";
+import { HeaderBackNavLink } from "../../../components/mobile/header/HeaderBackNavLink";
 import SectionTitle from "../../../components/common/SectionTitle/SectionTitle";
 import BtnBlue from "../../../components/common/BtnBlue/BtnBlue";
 import InfoRow from '../../../components/common/InfoRow/InfoRow'
 import { LuClipboardList } from 'react-icons/lu'
 import { ordersLinksService } from '../../../services/ordersLinksService'
 import { customerPortalService } from '../../../services/customerPortalService'
+import { CustomerOrderSummaryHeaderIcon } from '../../../components/mobile/header/CustomerOrderSummaryHeaderIcon';
 import type { Order } from '../../../services/ordersService'
 import { useNavigate } from 'react-router-dom'
 
@@ -55,7 +57,7 @@ const CustomerOrderHistory = () => {
         // 3. Cargar todas las ordenes del cliente
         const clientOrders = await customerPortalService.findOrdersByClient(clientId, token)
         // Ordenar por fecha de creación (más reciente primero)
-        const sortedOrders = clientOrders.sort((a, b) => {
+        const sortedOrders = clientOrders.sort((a: Order, b: Order) => {
           const dateA = new Date(a.createdAt).getTime()
           const dateB = new Date(b.createdAt).getTime()
           return dateB - dateA
@@ -136,15 +138,17 @@ const CustomerOrderHistory = () => {
   return (
     <>
             {/* Header */}        
-            <Header title="Historial de pedidos" subtitle="Cliente">
-              <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-              </svg>
-    
-              <svg width="24" height="24" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fillRule="evenodd" clipRule="evenodd" d="M18.25 0.75H1.75C0.921573 0.75 0.25 1.42157 0.25 2.25V15.75C0.25 16.5784 0.921573 17.25 1.75 17.25H18.25C19.0784 17.25 19.75 16.5784 19.75 15.75V2.25C19.75 1.42157 19.0784 0.75 18.25 0.75ZM18.25 15.75H1.75V2.25H18.25V15.75ZM14.5 5.25C14.5 7.73528 12.4853 9.75 10 9.75C7.51472 9.75 5.5 7.73528 5.5 5.25C5.5 4.83579 5.83579 4.5 6.25 4.5C6.66421 4.5 7 4.83579 7 5.25C7 6.90685 8.34315 8.25 10 8.25C11.6569 8.25 13 6.90685 13 5.25C13 4.83579 13.3358 4.5 13.75 4.5C14.1642 4.5 14.5 4.83579 14.5 5.25Z" fill="#0D141C"/>
-              </svg>
-            </Header>
+            <Header
+              title="Historial de pedidos"
+              subtitle="Cliente"
+              leftSlot={
+                <HeaderBackNavLink
+                  to={`/NewOrder${token ? `?token=${token}` : ''}`}
+                  ariaLabel="Volver al pedido"
+                />
+              }
+              rightSlot={<CustomerOrderSummaryHeaderIcon />}
+            />
     
             {/* Section Title */}
             <SectionTitle>

--- a/src/pages/Customer/mobile/HistoryOrderDetails.tsx
+++ b/src/pages/Customer/mobile/HistoryOrderDetails.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom';
 import Header from "../../../components/common/Header/Header";
+import { HeaderBackNavLink } from "../../../components/mobile/header/HeaderBackNavLink";
+import { CustomerOrderSummaryHeaderIcon } from '../../../components/mobile/header/CustomerOrderSummaryHeaderIcon';
 import SectionTitle from "../../../components/common/SectionTitle/SectionTitle";
 import BtnBlue from "../../../components/common/BtnBlue/BtnBlue";
 import ProductList from "../../../components/common/ProductList/ProductList";
@@ -128,23 +130,12 @@ const HistoryOrderDetails = () => {
   return (
     <>
       {/* Header */}        
-      <Header title={orderNumber} subtitle={orderDate}>
-        <svg 
-          width="24" 
-          height="24" 
-          viewBox="0 0 16 16" 
-          fill="none" 
-          xmlns="http://www.w3.org/2000/svg"
-          onClick={() => navigate(backPath)}
-          style={{ cursor: 'pointer' }}
-        >
-          <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-        </svg>
-
-        <svg width="24" height="24" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path fillRule="evenodd" clipRule="evenodd" d="M18.25 0.75H1.75C0.921573 0.75 0.25 1.42157 0.25 2.25V15.75C0.25 16.5784 0.921573 17.25 1.75 17.25H18.25C19.0784 17.25 19.75 16.5784 19.75 15.75V2.25C19.75 1.42157 19.0784 0.75 18.25 0.75ZM18.25 15.75H1.75V2.25H18.25V15.75ZM14.5 5.25C14.5 7.73528 12.4853 9.75 10 9.75C7.51472 9.75 5.5 7.73528 5.5 5.25C5.5 4.83579 5.83579 4.5 6.25 4.5C6.66421 4.5 7 4.83579 7 5.25C7 6.90685 8.34315 8.25 10 8.25C11.6569 8.25 13 6.90685 13 5.25C13 4.83579 13.3358 4.5 13.75 4.5C14.1642 4.5 14.5 4.83579 14.5 5.25Z" fill="#0D141C"/>
-        </svg>
-      </Header>
+      <Header
+        title={orderNumber}
+        subtitle={orderDate}
+        leftSlot={<HeaderBackNavLink to={backPath} ariaLabel="Volver" />}
+        rightSlot={<CustomerOrderSummaryHeaderIcon />}
+      />
 
       {/* Section Title */}
       <SectionTitle>

--- a/src/pages/Customer/mobile/NewOrder.tsx
+++ b/src/pages/Customer/mobile/NewOrder.tsx
@@ -14,6 +14,7 @@ import { productsService, Product } from '../../../services/productsService'
 import { categoriesService } from '../../../services/categoriesService'
 import type { ProductItem } from '../../../components/desktop/CustomerPanels/types'
 import { mapApiProductToItem } from '../../../utils/mapProductItem'
+import { CustomerOrderSummaryHeaderIcon } from '../../../components/mobile/header/CustomerOrderSummaryHeaderIcon';
 
 const NewOrder = () => {
   const [searchParams] = useSearchParams()
@@ -265,15 +266,11 @@ const NewOrder = () => {
   return (
     <>
         {/* Header */}        
-        <Header title={orderNumber || 'Pedido'} subtitle={orderDate || ''}>
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3L13 13M13 3L3 13" stroke="#0D141C" strokeWidth="1.8" strokeLinecap="round"/>
-          </svg>
-
-          <svg width="24" height="24" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fillRule="evenodd" clipRule="evenodd" d="M18.25 0.75H1.75C0.921573 0.75 0.25 1.42157 0.25 2.25V15.75C0.25 16.5784 0.921573 17.25 1.75 17.25H18.25C19.0784 17.25 19.75 16.5784 19.75 15.75V2.25C19.75 1.42157 19.0784 0.75 18.25 0.75ZM18.25 15.75H1.75V2.25H18.25V15.75ZM14.5 5.25C14.5 7.73528 12.4853 9.75 10 9.75C7.51472 9.75 5.5 7.73528 5.5 5.25C5.5 4.83579 5.83579 4.5 6.25 4.5C6.66421 4.5 7 4.83579 7 5.25C7 6.90685 8.34315 8.25 10 8.25C11.6569 8.25 13 6.90685 13 5.25C13 4.83579 13.3358 4.5 13.75 4.5C14.1642 4.5 14.5 4.83579 14.5 5.25Z" fill="#0D141C"/>
-          </svg>
-        </Header>
+        <Header
+          title={orderNumber || 'Pedido'}
+          subtitle={orderDate || ''}
+          rightSlot={<CustomerOrderSummaryHeaderIcon />}
+        />
 
         {/* Customer Name Field */}
         <FormField

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -93,7 +93,6 @@ export default function LoginForm() {
           width="100%"
           height="3rem"
           borderRadius="0.75rem"
-          background="linear-gradient(195deg, rgba(43, 118, 184, 0.699), rgba(15, 55, 107, 0.459))"
           htmlType="submit"
           disabled={loading}
         >

--- a/src/utils/roleLabel.ts
+++ b/src/utils/roleLabel.ts
@@ -1,0 +1,9 @@
+/** Etiqueta legible para el rol; no expone datos sensibles. */
+export function formatRoleSubtitle(role: string | undefined | null): string {
+  if (!role) return 'Usuario';
+  const r = role.toLowerCase();
+  if (r === 'admin') return 'Admin';
+  if (r === 'seller') return 'Vendedor';
+  if (r === 'customer' || r === 'client' || r === 'cliente') return 'Cliente';
+  return 'Usuario';
+}


### PR DESCRIPTION
Agrega displayName en AuthContext (obtenido de/users/me) con refreshDisplayProfile, invocado al iniciar sesión y actualizar la sesión. Actualiza Header para aceptar título/subtítulo opcional y resolver valores predeterminados de displayName, nombre de usuario o un rol formateado (usando nuevas utils/roleLabel.ts). Actualiza HeaderDesktop para utilizar el respaldo displayName. Elimina los usos de títulos/subtítulos codificados en páginas de administración móvil para que Header pueda derivar valores automáticamente. EditProfile ahora llama a refreshDisplayProfile después de un guardado exitoso para actualizar el nombre visible. Agrega la utilidad formatRoleSubtitle para centralizar el mapeo de roles con etiquetas

Agrega un componente LogoutConfirmDialog reutilizable y usa el hook LogoutConfirm para centralizar la interfaz del flujo de confirmación de cierre de sesión. Refactoriza el encabezado común para aceptar leftSlot/rightSlot y cambia su diseño a una cuadrícula; Agrega componentes de íconos de encabezado móvil y un HeaderBackNavLink, y actualiza muchas páginas móviles de administración para usar los nuevos slots de encabezado. Integra el cuadro de diálogo de cierre de sesión en el encabezado y la barra lateral del escritorio (con un controlador de puntero para cerrar el menú del usuario), refactoriza SidebarItem/types para admitir un botón de cierre de sesión y aplica ajustes de estilo al encabezado, al menú desplegable del encabezado del escritorio y al CSS de la barra lateral.